### PR TITLE
fix: reduce image size from 14.8GB to ~1GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,22 +20,40 @@ RUN \
   apt-get install -y --no-install-recommends \
     python3 python3-pip ca-certificates
 
-# SLM + supergateway
+# Install SLM npm package WITHOUT running postinstall (skip torch/GPU deps).
+# Mode B uses Ollama for embeddings, so sentence-transformers/torch are unnecessary.
 RUN --mount=type=cache,target=/root/.npm \
-    npm install -g superlocalmemory supergateway
+    npm install -g --ignore-scripts superlocalmemory supergateway
 
-# Patch: increase worker timeout from 60s to 300s
+# Install only the Python dependencies needed for Mode B (Ollama).
+# Core deps from pyproject.toml [project.dependencies] — NO [search] extras.
+# This avoids torch (~2GB), sentence-transformers (~500MB), onnxruntime (~200MB).
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --break-system-packages \
+      "numpy>=1.26.0,<3.0.0" \
+      "scipy>=1.12.0,<2.0.0" \
+      "networkx>=3.0" \
+      "httpx>=0.24.0" \
+      "python-dateutil>=2.9.0" \
+      "rank-bm25>=0.2.2" \
+      "vaderSentiment>=3.3.2" \
+      "einops>=0.8.2" \
+      "mcp>=1.0.0" \
+      "fastapi[all]>=0.135.1" \
+      "uvicorn>=0.42.0" \
+      "websockets>=16.0" \
+      "lightgbm>=4.0.0" \
+      "diskcache>=5.6.0" \
+      "orjson>=3.9.0"
+
+# pip install the SLM package itself (from npm-installed source, no extras)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    SLM_PKG=$(find /usr/local/lib/node_modules/superlocalmemory -name "pyproject.toml" -maxdepth 1 -printf '%h' -quit) \
+    && pip install --no-cache-dir --break-system-packages --no-deps "$SLM_PKG"
+
+# Patch: increase worker timeout from 60s to 300s for CPU/slow-GPU inference
 RUN find / -name "worker_pool.py" -path "*/superlocalmemory/*" -exec \
     sed -i 's/_REQUEST_TIMEOUT = 60/_REQUEST_TIMEOUT = 300/' {} + 2>/dev/null || true
-
-# Mode B: remove GPU deps (saves ~5GB)
-RUN find / -type d \( \
-    -name "nvidia" -o -name "torch" -o -name "triton" -o -name "sympy" \
-    -o -name "cuda" -o -name "sklearn" -o -name "transformers" \
-    -o -name "sentence_transformers" -o -name "safetensors" \
-    -o -name "tokenizers" \
-    \) -path "*/dist-packages/*" -exec rm -rf {} + 2>/dev/null || true && \
-    rm -rf /root/.cache 2>/dev/null || true
 
 # Dashboard
 COPY --from=dashboard-builder /dashboard/.next/standalone /app/dashboard


### PR DESCRIPTION
## Summary
- Skip npm postinstall (`--ignore-scripts`) to avoid torch/GPU dependencies (~7GB)
- Mode B uses Ollama for embeddings — `[search]` extras (torch, sentence-transformers, onnxruntime) are unnecessary
- Manually pip install only core + ui + learning + performance deps

## Result
- **Before:** 14.8GB
- **After:** 1.03GB (93% reduction)

## Test plan
- [x] `docker build` succeeds
- [ ] SLM starts in Mode B with Ollama
- [ ] `slm status` / `slm mcp` works correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)