### PR TITLE
fix(build): add missing react-is dep and fix Pie label type error

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -209,8 +209,8 @@ export default function DashboardPage() {
                   cx="50%"
                   cy="50%"
                   outerRadius={70}
-                  label={({ name, percent }: { name: string; percent: number }) =>
-                    `${name} (${(percent * 100).toFixed(0)}%)`
+                  label={({ name, percent }: { name?: string; percent?: number }) =>
+                    `${name ?? ''} (${((percent ?? 0) * 100).toFixed(0)}%)`
                   }
                 >
                   {sourceCounts.map((_, i) => (

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,6 +12,7 @@
         "pino": "^10.3.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-is": "^19.2.4",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -7313,6 +7314,12 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -28,6 +28,7 @@
     "pino": "^10.3.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-is": "^19.2.4",
     "recharts": "^3.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Docker ビルド (`npm run build`) が2つの原因で失敗していた問題を修正。

1. **`react-is` 依存不足** — `recharts` が `react-is` を require するが、明示的な dependency に含まれていなかった。`npm install react-is` で追加
2. **PieChart label 型エラー** — recharts の `PieLabelRenderProps` では `name` と `percent` が `undefined` になりうるが、`{ name: string; percent: number }` と型指定していたため Next.js の strict ビルドで型エラー。optional に修正

## Test plan

- [x] `npm run build` がローカルで成功
- [x] Vitest 30テスト全通過
- [ ] Docker ビルド (`build-push`) が CI で成功することを確認

https://claude.ai/code/session_01Bi3gK3ta3zhhcidgqc8XVE